### PR TITLE
Fix a typo in 02_vulnerability_analysis.md

### DIFF
--- a/handbooks/02_vulnerability_analysis.md
+++ b/handbooks/02_vulnerability_analysis.md
@@ -232,7 +232,7 @@ mqtt port:1883
 
 Browse: /api/v1/secrets
 
-### Cobald Strike Servers
+### Cobalt Strike Servers
 
 ```c
 "HTTP/1.1 404 Not Found" "Content-Type: text/plain" "Content-Length: 0" "Date" -"Server" -"Connection" -"Expires" -"Access-Control" -"Set-Cookie" -"Content-Encoding" -"Charset"


### PR DESCRIPTION
- Fix typo on `Cobalt Strike`

> PS: Very nice handbook, thanks a lot for sharing such awesome contents to the public