### PR TITLE
Add NullSec Linux to Hardware resources

### DIFF
--- a/handbooks/hardware.md
+++ b/handbooks/hardware.md
@@ -15,6 +15,7 @@
 | Bash-RF PI | Script with several tools to brute force garages, hack radio stations and capture and analyze radio signals with Raspberry Pi | https://github.com/Lucstay11/Brute-force-garage-and-hack-rf |
 | Firmware Analysis Toolkit | Toolkit to emulate firmware and analyse it for security vulnerabilities | https://github.com/attify/firmware-analysis-toolkit |
 | HardwareAllTheThings | Hardware/IOT Pentesting Wiki | https://github.com/swisskyrepo/HardwareAllTheThings |
+| NullSec Linux | Debian-based security distribution for hardware hacking with Flipper Zero, WiFi Pineapple, USB Rubber Ducky, and Bash Bunny integration. | https://github.com/bad-antics/nullsec-linux |
 | OWASP Firmware Security Testing Methodology | FSTM is composed of nine stages tailored to enable security researchers, software developers, hobbyists, and Information Security professionals with conducting firmware security assessments. | https://scriptingxss.gitbook.io/firmware-security-testing-methodology |
 | P4wnP1 A.L.O.A. | P4wnP1 A.L.O.A. by MaMe82 is a framework which turns a Rapsberry Pi Zero W into a flexible, low-cost platform for pentesting, red teaming and physical engagements ... or into "A Little Offensive Appliance". | https://github.com/RoganDawes/P4wnP1_aloa |
 | P4wnP1 by MaMe82 | P4wnP1 is a highly customizable USB attack platform, based on a low cost Raspberry Pi Zero or Raspberry Pi Zero W (required for HID backdoor). | https://github.com/RoganDawes/P4wnP1 |


### PR DESCRIPTION
Adding NullSec Linux to the Hardware handbook resources table.

**NullSec Linux** - Debian-based security distribution for hardware hacking with:
- Flipper Zero integration
- WiFi Pineapple support  
- USB Rubber Ducky / Bash Bunny tools
- Pre-configured pentesting workflows

Repository: https://github.com/bad-antics/nullsec-linux

This fits well with the hardware pentesting theme alongside P4wnP1, HardwareAllTheThings, etc.