### PR TITLE
Add CVE PoC Search to the CVE handbook

### DIFF
--- a/handbooks/cve.md
+++ b/handbooks/cve.md
@@ -68,6 +68,7 @@
 | Sploitus | https://sploitus.com |
 | Packet Storm | https://packetstormsecurity.com |
 | 0day.today Exploit Database | https://0day.today |
+| CVE PoC Search | https://labs.jamessawyer.co.uk/cves/ |
 
 ## Resources
 


### PR DESCRIPTION
## Summary
- add CVE PoC Search to the exploit databases table in the CVE handbook
- keep the existing table format unchanged

Tool link: https://labs.jamessawyer.co.uk/cves/