### PR TITLE
Add Lullar (people/username search)

### DIFF
--- a/handbooks/osint.md
+++ b/handbooks/osint.md
@@ -25,6 +25,7 @@
 | hunter | Hunter lets you find professional email addresses in seconds and connect with the people that matter for your business. | https://hunter.io |
 | Intelligence X | OSINT Search Engine | https://intelx.io |
 | linkedin2username | Generate username lists from companies on LinkedIn. | https://github.com/initstring/linkedin2username |
+| Lullar | Free people search by email, username or name across 175+ social networks | https://com.lullar.com/ |
 | NerdyData | Get a list of websites that use certain technologies, plus their company and spend data. | https://www.nerdydata.com |
 | Osintgram | Osintgram is a OSINT tool on Instagram. It offers an interactive shell to perform analysis on Instagram account of any users by its nickname. | https://github.com/Datalux/Osintgram |
 | OSINT Recon Tool | OSINT Mindmap Tool | https://recontool.org/#mindmap |


### PR DESCRIPTION
Reopening #9 with a signed commit as requested — thanks for the review on that one.

Adds Lullar to the OSINT resources table: free people search by email, username or first/last name across 175+ social networks, online since 2009. Same one-row change as before, inserted alphabetically between linkedin2username and NerdyData.

Disclosure: I run the tool.