### PR TITLE
docs: fix broken iconv anchor in payloads table of contents

### DIFF
--- a/handbooks/payloads.md
+++ b/handbooks/payloads.md
@@ -19,7 +19,7 @@
 - [GIF](#gif)
 - [Groovy (Jenkins) Reverse Shell](#groovy-jenkins-reverse-shell)
 - [HoaxShell](#hoaxshell)
-- [iconv](#iconf)
+- [iconv](#iconv)
 - [JAVA Reverse Shell](#java-reverse-shell)
 - [JAVA Web Shell](#java-web-shell)
 - [JavaScript Keylogger](#javascript-keylogger)


### PR DESCRIPTION
Signed re-submission of #12. The table-of-contents entry for `iconv` links to `#iconf`, but the section heading is `## iconv`, so the anchor should be `#iconv`. This fixes the broken link.