### PR TITLE
docs: fix broken TOC anchor links in three handbooks

### DIFF
--- a/handbooks/mobile.md
+++ b/handbooks/mobile.md
@@ -1,6 +1,6 @@
 # Mobile
 
-- [Resources](#resource)
+- [Resources](#resources)
 
 ## Table of Contents
 

--- a/handbooks/persistence.md
+++ b/handbooks/persistence.md
@@ -12,7 +12,7 @@
 - [Normal.dotm](#normaldotm)
 - [Quick Persistence](#quick-persistence)
 - [Registry Writes Without Registry Callbacks](#registry-writes-without-registry-callbacks)
-- [Relative ID (RID) Hijacking](#relative-id-rid-hjacking)
+- [Relative ID (RID) Hijacking](#relative-id-rid-hijacking)
 - [Security Descriptor Modification](#security-descriptor-modification)
 - [Special Privileges and Security Descriptors](#special-privileges-and-security-descriptors)
 - [SSH Public Key Backdoor](#ssh-public-key-backdoor)

--- a/handbooks/threat_hunting.md
+++ b/handbooks/threat_hunting.md
@@ -4,7 +4,7 @@
 
 ## Table of Contents
 
-- [Advanced Threat Analytics](#advanced-yhreat-analytics)
+- [Advanced Threat Analytics](#advanced-threat-analytics)
 - [Hunting Process Injection by Windows API Calls](#hunting-process-injection-by-windows-api-calls)
 - [Kusto Query Language (KQL)](#kusto-query-language-kql)
 - [Named Pipes](#named-pipes)


### PR DESCRIPTION
While reading through the handbooks I noticed a few Table of Contents links that point to the wrong anchor, so clicking them does not jump to the section. In each case the heading and the visible link text are already correct, and only the anchor slug has a small typo:

- `handbooks/persistence.md`: `[Relative ID (RID) Hijacking]` links to `#relative-id-rid-hjacking` (missing the `i`); the heading generates `#relative-id-rid-hijacking`.
- `handbooks/threat_hunting.md`: `[Advanced Threat Analytics]` links to `#advanced-yhreat-analytics` (`yhreat`); the heading generates `#advanced-threat-analytics`.
- `handbooks/mobile.md`: `[Resources]` links to `#resource`; the heading is `Resources`, so the slug is `#resources`.

The neighbouring TOC entries in each file already resolve correctly, so these are three isolated typos. No content changes, only the anchor links.
